### PR TITLE
fix odd check in sm2 point y-coordinate decompress

### DIFF
--- a/lib/sm2.js
+++ b/lib/sm2.js
@@ -73,7 +73,7 @@ function _sm2Point(x, y, parity) {
     var px = new BN(x, 16).toRed(SM2.red);
     var py = px.redSqr().redMul(px);
     py = py.redIAdd(px.redMul(SM2.a)).redIAdd(SM2.b).redSqrt();
-    if ((parity === 'odd') != py.isOdd()) {
+    if ((parity === 'odd') != py.fromRed().isOdd()) {
       py = py.redNeg();
     }
     pt = SM2.point(px, py);


### PR DESCRIPTION
Hello,

your check for odd number is not working and therefore I can not use compressed public key. I replaced the check with code from https://github.com/indutny/elliptic/blob/master/lib/elliptic/curve/short.js