### PR TITLE
fix leading zero padding in sm3 hex output

### DIFF
--- a/lib/sm2.js
+++ b/lib/sm2.js
@@ -391,8 +391,8 @@ SM2KeyPair.prototype.signDigest = function(digest) {
     var t2 = k.sub(r.mul(this.pri)).umod(this.curve.n);
     var s = t1.mul(t2).umod(this.curve.n);
     if (!s.isZero()) {
-      signature.r = r.toString(16);
-      signature.s = s.toString(16);
+      signature.r = utils.padStart(r.toString(16), 64, '0');
+      signature.s = utils.padStart(s.toString(16), 64, '0');
       break;
     }
   }
@@ -463,7 +463,7 @@ SM2KeyPair.prototype.toString = function() {
   }
   s += ", private: ";
   if (this.pri) {
-    s += this.pri.toString(16);
+    s += utils.padStart(this.pri.toString(16), 64, '0');
   } else {
     s += "null";
   }

--- a/lib/sm3.js
+++ b/lib/sm3.js
@@ -84,7 +84,7 @@ SM3.prototype.sum = function(msg, enc) {
   if (enc == 'hex') {
     digest = "";
     for (var i = 0; i < 8; i++) {
-      digest += utils.padStart(this.reg[i].toString(16));
+      digest += utils.padStart(this.reg[i].toString(16), 8, '0');
     }
   } else {
     var digest = new Array(32);

--- a/lib/sm3.js
+++ b/lib/sm3.js
@@ -84,7 +84,7 @@ SM3.prototype.sum = function(msg, enc) {
   if (enc == 'hex') {
     digest = "";
     for (var i = 0; i < 8; i++) {
-      digest += this.reg[i].toString(16);
+      digest += utils.padStart(this.reg[i].toString(16));
     }
   } else {
     var digest = new Array(32);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,7 @@ var crypto = require('crypto');
 utils.strToBytes = strToBytes;
 utils.hashToBN = hashToBN;
 utils.random = random;
+utils.padStart = padStart;
 
 function strToBytes(s) {
   var ch, st, re = [];
@@ -40,6 +41,21 @@ function hashToBN(hash) {
       hex += b;
     }
     return new BN(hex, 16);
+  }
+}
+
+/**
+ * Pads supplied string with character to fill the desired length.
+ * 
+ * @param {*} str String to pad
+ * @param {*} length Desired length of result string
+ * @param {*} padChar Character to use as padding
+ */
+function padStart(str, length, padChar) {
+  if (str.length >= length) {
+      return str;
+  } else {
+      return padChar.repeat(length - str.length) + str;
   }
 }
 


### PR DESCRIPTION
Hello,

I tried to hash text string 'test' and output the result to hex format.
The result was '55e12e91650d2fec56ec74e1d3e4ddbfce2ef3a65890c2a19ecf88a37e76a23'
instead of '55e12e91650d2fec56ec74e1d3e4ddbfce2ef3a65890c2a19ecf88a307e76a23'.